### PR TITLE
ipn issue resolved in magento 2.3

### DIFF
--- a/Plugin/CsrfValidatorSkip.php
+++ b/Plugin/CsrfValidatorSkip.php
@@ -1,0 +1,23 @@
+<?php
+namespace EMerchantPay\Genesis\Plugin;
+
+class CsrfValidatorSkip
+{
+    /**
+     * @param \Magento\Framework\App\Request\CsrfValidator $subject
+     * @param \Closure $proceed
+     * @param \Magento\Framework\App\RequestInterface $request
+     * @param \Magento\Framework\App\ActionInterface $action
+     */
+    public function aroundValidate(
+        $subject,
+        \Closure $proceed,
+        $request,
+        $action
+    ) {
+        if ($request->getModuleName() == 'emerchantpay') {
+            return; // Skip CSRF check
+        }
+        $proceed($request, $action); // Proceed Magento 2 core functionalities
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\App\Request\CsrfValidator">
+        <plugin name="csrf_validator_skip" type="EMerchantPay\Genesis\Plugin\CsrfValidatorSkip" />
+    </type>
+</config>


### PR DESCRIPTION
Issue Faced: 
- WPF Notifications Status: Failed
- Error Found in var/log/debug.log : main.DEBUG: Request validation failed for action "EMerchantPay\Genesis\Controller\Ipn\Index\Interceptor" []

Solution:
- Issue fixed in Magento 2.3.3 by skipping the CSRF check.